### PR TITLE
Remove scalogram imports from __init__.py

### DIFF
--- a/pyTMST/__init__.py
+++ b/pyTMST/__init__.py
@@ -1,2 +1,1 @@
-from .pyTMST import AMa_spectrum, AMa_scalogram, AMi_spectrum, f0M_spectrum, f0M_scalogram, AMa_spec_params, AMa_scalogram_params, AMi_spec_params, f0M_spec_params
-
+from .pyTMST import AMa_spectrum, AMi_spectrum, f0M_spectrum, AMa_spec_params, AMi_spec_params, f0M_spec_params


### PR DESCRIPTION
Scalograms were removed in ca5163cf0a, but `__init__.py` still had import for them, thus breaking on a fresh install. This PR removes scalogram imports from `__init__.py`.