### PR TITLE
Fixes exception in f0M_spectrum when signal length is divisible by 20

### DIFF
--- a/pyTMST/pyTMST.py
+++ b/pyTMST/pyTMST.py
@@ -7,7 +7,7 @@ Python port of the [Temporal Modulation Spectrum Toolbox
 > for the computation of amplitude- and f0- modulation spectra and
 > spectrograms."
 
-This work is licensed under a Creative Commons Attribution-NonCommercial 4.0 
+This work is licensed under a Creative Commons Attribution-NonCommercial 4.0
 International License (CC BY-NC 4.0).
 You should have received a copy of the license along with this
 work. If not, see <https://creativecommons.org/licenses/by-nc/4.0/>.
@@ -36,18 +36,18 @@ def AMa_spectrum(sig, fs, mfmin=0.5, mfmax=200, modbank_Nmod=200, fmin=70, fmax=
         raise ValueError("Invalid input types.")
     if fs <= 0:
         raise ValueError("fs must be a positive scalar.")
-    
+
     t = np.arange(1,len(sig)+1) / fs
     gamma_responses, fc = auditory_filterbank(sig, fs, fmin, fmax)
     E = np.abs(hilbert(gamma_responses, axis=1))
-    
+
     f_spectra, f_spectra_intervals = define_modulation_axis(mfmin, mfmax, modbank_Nmod)
     Nchan = fc.shape[0]
     AMspec = np.zeros((f_spectra.shape[0], Nchan))
     for ichan in range(Nchan):
         Pxx = periodogram(E[ichan, :], fs, f_spectra)
         AMspec[:, ichan] = 2 * Pxx
-   
+
     step = AMa_spec_params(t, aud_filt_bw(fc), gamma_responses, E, f_spectra, f_spectra_intervals)
     return AMspec, fc, f_spectra, step
 
@@ -57,7 +57,7 @@ def AMi_spectrum(sig, fs, mfmin=0.5, mfmax=200., modbank_Nmod=200, modbank_Qfact
         raise ValueError("Invalid input types.")
     if fs <= 0:
         raise ValueError("fs must be a positive scalar.")
-    
+
     t = np.arange(1,len(sig)+1) / fs
     gamma_responses, fc = auditory_filterbank(sig, fs, fmin, fmax)
     E = np.abs(hilbert(gamma_responses, axis=1))
@@ -80,8 +80,7 @@ def f0M_spectrum(sig, fs, mfmin=.5, mfmax=200., modbank_Nmod=200, undersample=20
     f0 = remove_artifacts(f0, fs/undersample, max_jump, min_duration, (fmin, fmax), (.4, 2.5), 1500)
     f0_wo_nan = f0[~np.isnan(f0)]
 
-    t = np.arange(1, len(sig) + 1) / fs
-    t_wo_nan = t[::undersample]
+    t_wo_nan = (np.arange(0, len(f0))*20 + 1)/fs
     t_wo_nan = t_wo_nan[:len(f0)]
     t_wo_nan = t_wo_nan[~np.isnan(f0)]
 
@@ -95,4 +94,3 @@ def f0M_spectrum(sig, fs, mfmin=.5, mfmax=200., modbank_Nmod=200, undersample=20
     step = f0M_spec_params(t_f0, f0, f_spectra, f_spectra_intervals)
 
     return f0M_spectrum, f_spectra, step
-


### PR DESCRIPTION

This fixes an `IndexError` exception that is thrown by f0M_spectrum when signal length is divisible by the default yin hop size of 20.

### Repro

```python
import librosa
import numpy as np
from pyTMST import f0M_spectrum

# load test signal
sig, sr = librosa.load("LaVoixHumaine_6s.wav", sr = None)

# truncate sig to a number of sample divisible by the default hop size
maxSample = np.trunc(len(sig)/20).astype(int)*20
sig = sig[:maxSample]

f0Mspec, f_spectra, step = f0M_spectrum(sig, sr)
```

Which produces this output:

```
File "(...)/pyTMST/pyTMST.py", line 86, in f0M_spectrum
    t_wo_nan = t_wo_nan[~np.isnan(f0)]
                      ~~~~~~~~^^^^^^^^^^^^^^^
IndexError: boolean index did not match indexed array along dimension 0; dimension is 4799 but corresponding boolean dimension is 4800
```

### Fix

This is due to the use of default parameter `center = True` in `librosa_yin_ap`, which pads the input to center frames on samples 0, hop, 2*hop, etc. When input signal is divisible by hop, this results in len(sig)/hop + 1 frames, as opposed to the len(sig)/hop frame expected by previous code.

Instead, we declare `t_wo_nan` as `(np.arange(0, len(f0))*20 + 1)/fs` to ensure it always has the same lenght as `f0`.